### PR TITLE
A: [NSFW] whassup.fr

### DIFF
--- a/liste_fr.txt
+++ b/liste_fr.txt
@@ -17924,6 +17924,7 @@ bongacams.com##.popover_spygasm
 edcom.fr##.popup
 zebrascrossing.net##.post--0
 gamergen.com##.post-google
+whassup.fr##.post-meta
 businessinsider.fr##.post-push
 businessinsider.fr##.post-push-intel
 strastv.com##.post_pub

--- a/liste_fr.txt
+++ b/liste_fr.txt
@@ -356,6 +356,7 @@
 .fr/adv_
 .fr/adver/
 .fr/affiliate/
+.fr/affiliates/
 .fr/js/out.js
 .fr/publicity/
 .get_pinder_ads


### PR DESCRIPTION
Block affiliate banner + hide Banners all over the page

PS: I opt for a more generic filter due to the similarity between that one: `.fr/affiliate/`

Screenshots:
<img width="1171" alt="Screenshot 2022-02-11 at 10 54 06" src="https://user-images.githubusercontent.com/65717387/153572243-a412b035-0a3e-4e90-a8f0-d8f2a22fd2cf.png">
<img width="1061" alt="Screenshot 2022-02-11 at 10 55 51" src="https://user-images.githubusercontent.com/65717387/153572253-969cba6b-42e8-4d0d-ac31-f2481fff9b2a.png">

