### PR TITLE
D: breaking websites

### DIFF
--- a/liste_fr.txt
+++ b/liste_fr.txt
@@ -20084,7 +20084,6 @@ $stylesheet,third-party,domain=1fichier.com|7-up.net|9xupload.me|adshr.ink|adshr
 ##.adcarousel
 ##.adcol
 ##.add-block
-##.add-space
 ##.addblock
 ##.addbygoogle
 ##.adds-block


### PR DESCRIPTION
Please approve the removal of this generic filter from the generic filters as it does break content on the pages. And also the name .add-space and can be used for actual purpose of adding space inside the containers, not as space for ads.
For example on this page the user cant display their contented because this generic filter in the fr list is blocking the content. (**[see video](https://www.youtube.com/watch?v=TRqLqjDoLNI)** ) for this website `https://plexx.mallinidesign.com/portfolio/portfolio-3-masonry/`

Thanks a lot