### PR TITLE
M: Removed filter (://ban.$third-party)

### DIFF
--- a/liste_fr.txt
+++ b/liste_fr.txt
@@ -2301,7 +2301,6 @@
 ://afflight.$third-party
 ://ar.ads.
 ://ashot.$script
-://ban.$third-party
 ://banner-gateway.$third-party
 ://banner.*click
 ://banner.*utm_


### PR DESCRIPTION
`://ban.$third-party` - was blocking all domains (not subdomains) from receive/send data

![image](https://github.com/easylist/listefr/assets/17812651/8bcc0af2-a9a6-45fb-a505-f14efc808dd4)
