### PR TITLE
A: hide kamino banners

### DIFF
--- a/liste_fr.txt
+++ b/liste_fr.txt
@@ -13147,6 +13147,7 @@ $stylesheet,third-party,domain=1fichier.com|7-up.net|9xupload.me|adshrinks.com|a
 ##[class*="-ad-placeholder-"]
 ##[data-ad-position]
 ##[data-ad-text]
+##[data-component-id="kamino"]
 ##[id^="adswidget"]
 ##[id^="dfp_ban_"]
 ##[id^="dfp_banner"]


### PR DESCRIPTION
Hides ads from [Kamino](https://www.kaminoretail.com/)'s network.

Fixes #284