### PR TITLE
Remove non.li third-party filter

### DIFF
--- a/liste_fr.txt
+++ b/liste_fr.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 2.0]
-! Checksum: FdBU04J0bfT5uyhdAC5t1Q
-! Version: 20260621030635
+! Checksum: OqQmh8VzOROKRVEKTJ6Aew
+! Version: 20260622105626
 ! Title: Liste FR
 ! Expires: 1 days
 ! Description: Filtres publicitaires francophones complémentaires à EasyList
@@ -1280,7 +1280,6 @@ _build=iclick-$popup
 ||ninjagod.com^$third-party
 ||ninjapd.com^$third-party
 ||no-adblock.com^$third-party
-||non.li^$third-party
 ||nr-data.net^$third-party
 ||nsfxaffiliates.com^$third-party
 ||ntl.cloud^$third-party


### PR DESCRIPTION
## Summary

Remove the generic `||non.li^$third-party` filter from Liste FR.

## Context

This domain-level rule is too broad for the current Nonli service. `non.li` is used for legitimate publisher infrastructure, including:

- publisher shortlink / redirect domains such as `l.numerama.com`, which resolve to Nonli redirect infrastructure;
- the Nonli SDK / analytics tag infrastructure used by media publishers.

We are seeing this rule produce false positives when downstream products consume Liste FR for DNS/ad/tracker blocking. For example, NordVPN CyberSec currently returns `NXDOMAIN` for `l.numerama.com` via its ad/tracker DNS filtering, while the domain is a legitimate publisher shortlink and resolves to `tls.non.li` outside that filtering path.

The SDK side is also important: Nonli’s current SDK documentation explains that the analytics tag is served from a customer subdomain, performs traffic analysis anonymously on Nonli servers, drops no cookie in the visitor browser, reads no cookies, does not reconstruct individual journeys, and never consolidates data across different domains: https://www.nonli.com/en/faq/nonli-sdk-analytics-tag-q-a

Because of that, blocking the whole `non.li` domain as a third-party tracker is no longer accurate. If a specific legacy pattern still needs filtering, it should be targeted more narrowly than the entire `non.li` domain.

## Verification

- Removed only `||non.li^$third-party` from `liste_fr.txt`
- Regenerated the ABP checksum/version with `perl addChecksum.pl liste_fr.txt`